### PR TITLE
fix parse dashboard startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - mongo
   dashboard:
     image: parseplatform/parse-dashboard
-    command: --dev --appId APPLICATION_ID --masterKey MASTER_KEY --appName affinity
+    command: --dev --appId APPLICATION_ID --masterKey MASTER_KEY --serverURL "${VUE_APP_PARSE_URL}" --appName affinity
     ports:
       - 4040:4040
     links:


### PR DESCRIPTION
I just added the `serverUrl` to startup via env variable, so we are able to use the parse dashboard again. Important for tasks that deal with db. Alternative would be to work with a locally installed parse dashboard.