### PR TITLE
Double login issue #137

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
-    "test:e2e": "vue-cli-service test:e2e --url http://localhost:8100/",
+    "test:e2e": "vue-cli-service test:e2e --url http://localhost:8080/",
     "build:widget": "vue-cli-service build --target wc --inline-vue --name affinity-chat ./src/components/config/Widget.vue",
     "ci:run-parse": "npm run dev:build-parse && docker-compose up -d && docker-compose logs --tail 30",
     "ci:setup-db": "npm run dev:db && npm run dev:db:mock-data && cp .env.development.local.template .env.development.local",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
-    "test:e2e": "vue-cli-service test:e2e --url http://localhost:8080/",
+    "test:e2e": "vue-cli-service test:e2e --url http://localhost:8100/",
     "build:widget": "vue-cli-service build --target wc --inline-vue --name affinity-chat ./src/components/config/Widget.vue",
     "ci:run-parse": "npm run dev:build-parse && docker-compose up -d && docker-compose logs --tail 30",
     "ci:setup-db": "npm run dev:db && npm run dev:db:mock-data && cp .env.development.local.template .env.development.local",

--- a/src/components/anon-menu.vue
+++ b/src/components/anon-menu.vue
@@ -40,7 +40,6 @@ export default defineComponent({
     return {
         login() {
             store.dispatch("auth/openLogin");
-            popoverController.dismiss();
         },
         notificationIcon, logInIcon
     }

--- a/src/config/App.vue
+++ b/src/config/App.vue
@@ -26,6 +26,7 @@ import {
   modalController,
   isPlatform,
   toastController,
+  popoverController,
 } from "@ionic/vue";
 import { logInOutline as logInIcon } from "ionicons/icons";
 import { defineComponent, computed, watch } from "vue";
@@ -79,8 +80,9 @@ export default defineComponent({
           component: LoginModal,
         });
         loginModal.present();
-        loginModal.onDidDismiss().then(() => {
+        loginModal.onWillDismiss().then((): void => {
           store.dispatch("auth/dismissLogin");
+          if (isPlatform("android") || isPlatform("ios")) popoverController.dismiss();
         });
       } else if (!newVal && loginModal) {
         loginModal.dismiss();
@@ -150,7 +152,6 @@ export default defineComponent({
       teamStyles: computed(() => store.getters.defaultTeam?.customStyles),
       openLoginModal: () => store.dispatch("auth/openLogin"),
       loading: store.getters.isLoading,
-      // openLoginModal: () => store.dispatch("auth/openLogin"),
       fetchUser: () => store.dispatch("auth/fetchUser"),
     };
   },


### PR DESCRIPTION
The bug is triggered only when using the footer-menu popover (@click=openMenuPopover) on real devices.

We notice that when entering "login-modal.vue" it reloads all the elements there (in this case "login.vue"), this duplicate loading occurs right after the popover closes.
`popoverController.dismiss();`

https://user-images.githubusercontent.com/31784632/115717386-0aef8280-a372-11eb-9a87-a4f56e6a138d.mp4



I thought there had to be a time delay to solve the problem but whenever the popover is closed within the "login-modal" it duplicates the element.

`setTimeout(() => {
          popoverController.dismiss();
        }, 5000);`

![setimeout](https://user-images.githubusercontent.com/31784632/115715362-f5795900-a36f-11eb-903b-2cdf0ea70097.gif)



I removed the popover closure and everything was fine, but...
closing the modal makes it inelegant to see an open popover.

![mantemAberto](https://user-images.githubusercontent.com/31784632/115715758-615bc180-a370-11eb-8346-883428a37134.gif)


Then I went to where the modal is created, determined that it should close the popover when the login page is dismissed and when using a real device (Reason for error).

![finish](https://user-images.githubusercontent.com/31784632/115716193-d62efb80-a370-11eb-97c9-739c5c24532c.gif)
