### PR TITLE
fix: always set default background color

### DIFF
--- a/src/components/news-item.vue
+++ b/src/components/news-item.vue
@@ -173,9 +173,12 @@ export default defineComponent({
       return {}
     },
     extraStyle(): object {
-      const style = (this.item.extra || {})["styles"] || {
-        background: "var(--ion-color-tertiary )",
-      };
+      const style = Object.assign(
+        {
+          background: "var(--ion-color-tertiary )",
+        },
+        (this.item.extra || {})["styles"]
+      );
       const localStyle = {
         "z-index": this.zIndex,
       };


### PR DESCRIPTION
Ist mir nebenbei aufgefallen: Für Posts, die eigene Styles mitbringen (z. B. Bilder) wird kein default Hintergrund gesetzt, auch wenn sie selbst auch keinen Hintergrund setzen. Das führt dazu, dass der Newsfeed beispielsweise bei Bildern mit transparenten Stellen kaputt geht:

![Screengif Jun-23-2021 15-18-22](https://user-images.githubusercontent.com/24372341/123104393-3278cf00-d437-11eb-8bca-0dd155cc57f1.gif)
