### PR TITLE
fix: color light is too light for lines

### DIFF
--- a/src/components/comment.vue
+++ b/src/components/comment.vue
@@ -15,7 +15,7 @@
         {{ text }}
       </div>
       <div>
-        <ion-chip @click="showInput = !showInput" outline :color="showInput? 'medium' : 'light'">
+        <ion-chip @click="showInput = !showInput" outline :color="showInput? 'dark' : 'medium'">
           <ion-icon :icon="replyIcon" size="small" />
         </ion-chip>
 
@@ -32,7 +32,7 @@
           <ion-label>{{ r.key }}</ion-label>
           <ion-label>{{ r.count }}</ion-label>
         </ion-chip>
-        <ion-chip outline color="light">
+        <ion-chip outline color="medium">
           <ion-icon :icon="plusIcon" size="small" />
         </ion-chip>
       </div>
@@ -153,7 +153,7 @@ export default defineComponent({
       );
     },
     likedColor(): string {
-      return this.hasLiked ? "danger" : "light";
+      return this.hasLiked ? "danger" : "medium";
     },
     authorName(): string {
       const author = this.author;
@@ -166,7 +166,7 @@ export default defineComponent({
           key,
           color:
             reactors.indexOf(this.store.getters["auth/myId"]) === -1
-              ? "light"
+              ? "medium"
               : "dark",
           count: reactors.length,
         };
@@ -237,7 +237,7 @@ ion-card-header {
   align-items: center;
 }
 .sub-comments-box {
-  border-left: 2px solid var(--ion-color-light);
+  border-left: 2px solid var(--ion-color-medium);
 }
 
   .avatar-col {

--- a/src/components/interaction-bar.vue
+++ b/src/components/interaction-bar.vue
@@ -3,14 +3,14 @@
     <ion-chip
       @click="toggleComments()"
       outline
-      :color="showComments ? 'dark' : 'light'"
+      :color="showComments ? 'dark' : 'medium'"
     >
       <span class="interaction-button">
         <ion-icon :icon="commentsIcon" size="small" />
         <ion-label>{{ object.commentsCount }}</ion-label>
       </span>
     </ion-chip>
-    <ion-chip outline color="light">
+    <ion-chip outline color="medium">
       <share-button
         :link="fullLink"
         :pointer="pointer"
@@ -132,7 +132,7 @@ export default defineComponent({
       return [];
     },
     likedColor(): string {
-      return this.hasLiked ? "danger" : "light";
+      return this.hasLiked ? "danger" : "medium";
     },
   },
   methods: {

--- a/src/components/login.vue
+++ b/src/components/login.vue
@@ -122,7 +122,7 @@
         </ion-button>
       </ion-item>
       <ion-item class="ion-hide-sm-up" lines="none">
-        <ion-button @click="passwortReset" slot="end" fill="none" color="light">
+        <ion-button @click="passwortReset" slot="end" fill="none" color="medium">
           {{ $t("auth.button.resetPassword") }}
         </ion-button>
       </ion-item>

--- a/src/components/new-post.vue
+++ b/src/components/new-post.vue
@@ -528,7 +528,7 @@ export default defineComponent({
       showColorSelector: computed(() => store.getters["draft/selectedType"] == "announce" ),
 
       backgroundColor: computed(() => (store.getters["draft/extraStyles"].background || "var(--ion-color-primary)")),
-      buttonColor: computed(() => (store.getters["draft/extraStyles"].buttonColor || "var(--ion-color-light)")),
+      buttonColor: computed(() => (store.getters["draft/extraStyles"].buttonColor || "var(--ion-color-medium)")),
       setExtraStyle: (updates: any) => {
         store.commit("draft/setExtraStyle", updates);
       },

--- a/src/components/reactions.vue
+++ b/src/components/reactions.vue
@@ -56,7 +56,7 @@ export default defineComponent({
     },
     unselectedColor: {
       type: String,
-      default: "light",
+      default: "medium",
     },
     item: {
       type: Object,


### PR DESCRIPTION
fixes #273 

Turns out, it wasn't just a dark theme bug, it was relatively hard to see the lines in light mode as well. The `ion-color-light` is very similar to the background color and meant to be used eg as background color for buttons, but is too light to be used as the color for thin borders and outlines.